### PR TITLE
FIX: Strip all non-alphanum chars from string start for root test naming

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -655,7 +655,7 @@ def sanitize_appinsights(payload: dict) -> dict:
     name = re.sub(r"(\-\-)+", r"\1", name)
     name = name.strip()
     if re.match(r"^[^a-zA-Z]", name):
-        name = f"C-{name}"
+        name = re.sub(r"^([^\w]+)(.+)", r"\2", name)
     if len(name) > 64:
         name = f"{name[:-3]}..."
     payload.update(dict(name=name))


### PR DESCRIPTION
This will fix the naming sanitization for tests located directly in the root of the collection.

Let me know what you think.